### PR TITLE
feat: Static text improvements, help system, and Grok editing

### DIFF
--- a/MariBot-Core.Tests/AiModuleTests.cs
+++ b/MariBot-Core.Tests/AiModuleTests.cs
@@ -73,7 +73,7 @@ namespace MariBot.Core.Tests
         }
 
         [Fact]
-        public async Task GrokTextGeneration_LongResponse_TruncatesTo1990()
+        public async Task GrokTextGeneration_LongResponse_SendsMultipleMessages()
         {
             var longResponse = new string('A', 3000);
             mockGrokService.Setup(s => s.GetGrokResponseAsync(It.IsAny<string>()))
@@ -81,14 +81,13 @@ namespace MariBot.Core.Tests
 
             await module.GrokTextGeneration("test prompt");
 
-            // 1990 chars + "```\n" (4) + "\n```" (4) = 1998 max
             mockChannel.Verify(c => c.SendMessageAsync(
-                It.Is<string>(s => !s.Contains(longResponse) && s.Length <= 1998),
+                It.Is<string>(s => s.StartsWith("```") && s.EndsWith("```") && s.Length <= 2000),
                 It.IsAny<bool>(), It.IsAny<Embed>(), It.IsAny<RequestOptions>(),
                 It.IsAny<AllowedMentions>(), It.IsAny<MessageReference>(),
                 It.IsAny<MessageComponent>(), It.IsAny<ISticker[]>(),
                 It.IsAny<Embed[]>(), It.IsAny<MessageFlags>(), It.IsAny<PollProperties>()),
-                Times.Once);
+                Times.Exactly(2));
         }
 
         [Fact]

--- a/MariBot-Core.Tests/AiModuleTests.cs
+++ b/MariBot-Core.Tests/AiModuleTests.cs
@@ -183,6 +183,163 @@ namespace MariBot.Core.Tests
                 It.IsAny<Embed[]>(), It.IsAny<MessageFlags>(), It.IsAny<PollProperties>()),
                 Times.Once);
         }
+        // --- GrokImageEdit ---
+
+        private AiModule CreateModuleWithAttachments(params IAttachment[] attachments)
+        {
+            var mockMsg = new Mock<IUserMessage>();
+            mockMsg.Setup(m => m.Id).Returns(12345UL);
+            mockMsg.Setup(m => m.Attachments).Returns(attachments);
+            mockMsg.Setup(m => m.Reference).Returns((MessageReference)null!);
+
+            var mockCtx = new Mock<ICommandContext>();
+            mockCtx.Setup(c => c.Channel).Returns(mockChannel.Object);
+            mockCtx.Setup(c => c.Message).Returns(mockMsg.Object);
+
+            var mod = new AiModule(null!, null!, mockImageService.Object, null!, NullLogger<AiModule>.Instance, mockGrokService.Object);
+            ((IModuleBase)mod).SetContext(mockCtx.Object);
+            return mod;
+        }
+
+        private static IAttachment CreateMockAttachment(string url, string contentType)
+        {
+            var mock = new Mock<IAttachment>();
+            mock.Setup(a => a.Url).Returns(url);
+            mock.Setup(a => a.ContentType).Returns(contentType);
+            return mock.Object;
+        }
+
+        [Fact]
+        public async Task GrokImageEdit_OneAttachment_SendsEditedFile()
+        {
+            var attachment = CreateMockAttachment("https://example.com/photo.png", "image/png");
+            var mod = CreateModuleWithAttachments(attachment);
+
+            var fakeStream = new MemoryStream(new byte[] { 1, 2, 3 });
+            mockGrokService.Setup(s => s.GetGrokImageEditAsync(It.IsAny<string>(), It.IsAny<List<string>>()))
+                .ReturnsAsync("https://example.com/edited.png");
+            mockImageService.Setup(s => s.GetWebResource("https://example.com/edited.png"))
+                .ReturnsAsync(fakeStream);
+
+            await mod.GrokImageEdit("make it blue");
+
+            mockGrokService.Verify(s => s.GetGrokImageEditAsync("make it blue",
+                It.Is<List<string>>(l => l.Count == 1 && l[0] == "https://example.com/photo.png")), Times.Once);
+            mockChannel.Verify(c => c.SendFileAsync(
+                It.IsAny<Stream>(), It.Is<string>(s => s == "grok_edit.png"),
+                It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<Embed>(),
+                It.IsAny<RequestOptions>(), It.IsAny<bool>(), It.IsAny<AllowedMentions>(),
+                It.IsAny<MessageReference>(), It.IsAny<MessageComponent>(),
+                It.IsAny<ISticker[]>(), It.IsAny<Embed[]>(),
+                It.IsAny<MessageFlags>(), It.IsAny<PollProperties>()),
+                Times.Once);
+        }
+
+        [Fact]
+        public async Task GrokImageEdit_TwoAttachments_SendsEditedFile()
+        {
+            var attachment1 = CreateMockAttachment("https://example.com/photo1.png", "image/png");
+            var attachment2 = CreateMockAttachment("https://example.com/photo2.jpg", "image/jpeg");
+            var mod = CreateModuleWithAttachments(attachment1, attachment2);
+
+            var fakeStream = new MemoryStream(new byte[] { 1, 2, 3 });
+            mockGrokService.Setup(s => s.GetGrokImageEditAsync(It.IsAny<string>(), It.IsAny<List<string>>()))
+                .ReturnsAsync("https://example.com/edited.png");
+            mockImageService.Setup(s => s.GetWebResource("https://example.com/edited.png"))
+                .ReturnsAsync(fakeStream);
+
+            await mod.GrokImageEdit("combine these");
+
+            mockGrokService.Verify(s => s.GetGrokImageEditAsync("combine these",
+                It.Is<List<string>>(l => l.Count == 2 && l[0] == "https://example.com/photo1.png" && l[1] == "https://example.com/photo2.jpg")), Times.Once);
+            mockChannel.Verify(c => c.SendFileAsync(
+                It.IsAny<Stream>(), It.Is<string>(s => s == "grok_edit.png"),
+                It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<Embed>(),
+                It.IsAny<RequestOptions>(), It.IsAny<bool>(), It.IsAny<AllowedMentions>(),
+                It.IsAny<MessageReference>(), It.IsAny<MessageComponent>(),
+                It.IsAny<ISticker[]>(), It.IsAny<Embed[]>(),
+                It.IsAny<MessageFlags>(), It.IsAny<PollProperties>()),
+                Times.Once);
+        }
+
+        [Fact]
+        public async Task GrokImageEdit_NoImages_SendsErrorMessage()
+        {
+            var mod = CreateModuleWithAttachments();
+
+            await mod.GrokImageEdit("make it blue");
+
+            mockChannel.Verify(c => c.SendMessageAsync(
+                It.Is<string>(s => s.Contains("Please provide at least one image to edit")),
+                It.IsAny<bool>(), It.IsAny<Embed>(), It.IsAny<RequestOptions>(),
+                It.IsAny<AllowedMentions>(), It.IsAny<MessageReference>(),
+                It.IsAny<MessageComponent>(), It.IsAny<ISticker[]>(),
+                It.IsAny<Embed[]>(), It.IsAny<MessageFlags>(), It.IsAny<PollProperties>()),
+                Times.Once);
+            mockGrokService.Verify(s => s.GetGrokImageEditAsync(It.IsAny<string>(), It.IsAny<List<string>>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task GrokImageEdit_UnsupportedImageType_FiltersOut()
+        {
+            var gifAttachment = CreateMockAttachment("https://example.com/anim.gif", "image/gif");
+            var pngAttachment = CreateMockAttachment("https://example.com/photo.png", "image/png");
+            var mod = CreateModuleWithAttachments(gifAttachment, pngAttachment);
+
+            var fakeStream = new MemoryStream(new byte[] { 1, 2, 3 });
+            mockGrokService.Setup(s => s.GetGrokImageEditAsync(It.IsAny<string>(), It.IsAny<List<string>>()))
+                .ReturnsAsync("https://example.com/edited.png");
+            mockImageService.Setup(s => s.GetWebResource("https://example.com/edited.png"))
+                .ReturnsAsync(fakeStream);
+
+            await mod.GrokImageEdit("make it blue");
+
+            mockGrokService.Verify(s => s.GetGrokImageEditAsync("make it blue",
+                It.Is<List<string>>(l => l.Count == 1 && l[0] == "https://example.com/photo.png")), Times.Once);
+        }
+
+        [Fact]
+        public async Task GrokImageEdit_GrokServiceThrows_SendsErrorMessage()
+        {
+            var attachment = CreateMockAttachment("https://example.com/photo.png", "image/png");
+            var mod = CreateModuleWithAttachments(attachment);
+
+            mockGrokService.Setup(s => s.GetGrokImageEditAsync(It.IsAny<string>(), It.IsAny<List<string>>()))
+                .ThrowsAsync(new Exception("Edit failed"));
+
+            await mod.GrokImageEdit("make it blue");
+
+            mockChannel.Verify(c => c.SendMessageAsync(
+                It.Is<string>(s => s.Contains("Something went wrong") && s.Contains("Edit failed")),
+                It.IsAny<bool>(), It.IsAny<Embed>(), It.IsAny<RequestOptions>(),
+                It.IsAny<AllowedMentions>(), It.IsAny<MessageReference>(),
+                It.IsAny<MessageComponent>(), It.IsAny<ISticker[]>(),
+                It.IsAny<Embed[]>(), It.IsAny<MessageFlags>(), It.IsAny<PollProperties>()),
+                Times.Once);
+        }
+
+        [Fact]
+        public async Task GrokImageEdit_ImageServiceThrows_SendsErrorMessage()
+        {
+            var attachment = CreateMockAttachment("https://example.com/photo.png", "image/png");
+            var mod = CreateModuleWithAttachments(attachment);
+
+            mockGrokService.Setup(s => s.GetGrokImageEditAsync(It.IsAny<string>(), It.IsAny<List<string>>()))
+                .ReturnsAsync("https://example.com/edited.png");
+            mockImageService.Setup(s => s.GetWebResource(It.IsAny<string>()))
+                .ThrowsAsync(new Exception("Download failed"));
+
+            await mod.GrokImageEdit("make it blue");
+
+            mockChannel.Verify(c => c.SendMessageAsync(
+                It.Is<string>(s => s.Contains("Something went wrong") && s.Contains("Download failed")),
+                It.IsAny<bool>(), It.IsAny<Embed>(), It.IsAny<RequestOptions>(),
+                It.IsAny<AllowedMentions>(), It.IsAny<MessageReference>(),
+                It.IsAny<MessageComponent>(), It.IsAny<ISticker[]>(),
+                It.IsAny<Embed[]>(), It.IsAny<MessageFlags>(), It.IsAny<PollProperties>()),
+                Times.Once);
+        }
+
         // --- GrokVideoGeneration ---
 
         [Fact]

--- a/MariBot-Core.Tests/StaticTextListHelpersTests.cs
+++ b/MariBot-Core.Tests/StaticTextListHelpersTests.cs
@@ -1,0 +1,88 @@
+using MariBot.Core.Modules.Text;
+using Xunit;
+
+namespace MariBot.Core.Tests
+{
+    public class StaticTextListHelpersTests
+    {
+        // --- ChunkText ---
+
+        [Fact]
+        public void ChunkText_ShortText_ReturnsSingleChunk()
+        {
+            var result = StaticTextListHelpers.ChunkText("hello world", 3500);
+            Assert.Single(result);
+            Assert.Equal("hello world", result[0]);
+        }
+
+        [Fact]
+        public void ChunkText_LongTextWithNewlines_SplitsAtNewline()
+        {
+            var line = new string('a', 200);
+            // Build a string that is ~3600 chars with newlines every 200 chars
+            var text = string.Join("\n", Enumerable.Repeat(line, 18)); // 18 * 200 + 17 newlines = 3617 chars
+            var result = StaticTextListHelpers.ChunkText(text, 3500);
+            Assert.True(result.Count > 1);
+            foreach (var chunk in result)
+                Assert.True(chunk.Length <= 3500);
+        }
+
+        [Fact]
+        public void ChunkText_EmptyString_ReturnsSingleEmptyChunk()
+        {
+            var result = StaticTextListHelpers.ChunkText("", 3500);
+            // empty string produces no chunks since length is not > 0
+            Assert.Empty(result);
+        }
+
+        // --- BuildListPages ---
+
+        [Fact]
+        public void BuildListPages_EmptyLists_ReturnsSinglePageWithNone()
+        {
+            var pages = StaticTextListHelpers.BuildListPages(new List<string>(), new List<string>());
+            Assert.Single(pages);
+            Assert.Contains("None", pages[0].Description);
+        }
+
+        [Fact]
+        public void BuildListPages_SmallLists_ReturnsSinglePage()
+        {
+            var global = new List<string> { "cmd1", "cmd2" };
+            var guild = new List<string> { "guildcmd1" };
+            var pages = StaticTextListHelpers.BuildListPages(global, guild);
+            Assert.Single(pages);
+        }
+
+        [Fact]
+        public void BuildListPages_VeryLongLists_ReturnsMultiplePages()
+        {
+            // Create enough commands to exceed 3500 chars
+            var cmds = Enumerable.Range(1, 500).Select(i => $"command{i:D4}").ToList();
+            var pages = StaticTextListHelpers.BuildListPages(cmds, new List<string>());
+            Assert.True(pages.Count > 1);
+        }
+
+        [Fact]
+        public void BuildListPages_GlobalCommandsAppearInGlobalSection()
+        {
+            var global = new List<string> { "myglobalcmd" };
+            var guild = new List<string> { "myguildcmd" };
+            var pages = StaticTextListHelpers.BuildListPages(global, guild);
+            var allText = string.Join("", pages.Select(p => p.Description));
+            Assert.Contains("myglobalcmd", allText);
+            Assert.Contains("Global Commands", allText);
+        }
+
+        [Fact]
+        public void BuildListPages_GuildCommandsAppearInGuildSection()
+        {
+            var global = new List<string> { "globalcmd" };
+            var guild = new List<string> { "myguildcmd" };
+            var pages = StaticTextListHelpers.BuildListPages(global, guild);
+            var allText = string.Join("", pages.Select(p => p.Description));
+            Assert.Contains("myguildcmd", allText);
+            Assert.Contains("Guild Commands", allText);
+        }
+    }
+}

--- a/MariBot-Core.Tests/StaticTextListHelpersTests.cs
+++ b/MariBot-Core.Tests/StaticTextListHelpersTests.cs
@@ -1,4 +1,4 @@
-using MariBot.Core.Modules.Text;
+using MariBot.Core.Utils;
 using Xunit;
 
 namespace MariBot.Core.Tests
@@ -10,7 +10,7 @@ namespace MariBot.Core.Tests
         [Fact]
         public void ChunkText_ShortText_ReturnsSingleChunk()
         {
-            var result = StaticTextListHelpers.ChunkText("hello world", 3500);
+            var result = PaginationHelpers.ChunkText("hello world", 3500);
             Assert.Single(result);
             Assert.Equal("hello world", result[0]);
         }
@@ -21,7 +21,7 @@ namespace MariBot.Core.Tests
             var line = new string('a', 200);
             // Build a string that is ~3600 chars with newlines every 200 chars
             var text = string.Join("\n", Enumerable.Repeat(line, 18)); // 18 * 200 + 17 newlines = 3617 chars
-            var result = StaticTextListHelpers.ChunkText(text, 3500);
+            var result = PaginationHelpers.ChunkText(text, 3500);
             Assert.True(result.Count > 1);
             foreach (var chunk in result)
                 Assert.True(chunk.Length <= 3500);
@@ -30,7 +30,7 @@ namespace MariBot.Core.Tests
         [Fact]
         public void ChunkText_EmptyString_ReturnsSingleEmptyChunk()
         {
-            var result = StaticTextListHelpers.ChunkText("", 3500);
+            var result = PaginationHelpers.ChunkText("", 3500);
             // empty string produces no chunks since length is not > 0
             Assert.Empty(result);
         }
@@ -40,7 +40,7 @@ namespace MariBot.Core.Tests
         [Fact]
         public void BuildListPages_EmptyLists_ReturnsSinglePageWithNone()
         {
-            var pages = StaticTextListHelpers.BuildListPages(new List<string>(), new List<string>());
+            var pages = PaginationHelpers.BuildListPages(new List<string>(), new List<string>());
             Assert.Single(pages);
             Assert.Contains("None", pages[0].Description);
         }
@@ -50,7 +50,7 @@ namespace MariBot.Core.Tests
         {
             var global = new List<string> { "cmd1", "cmd2" };
             var guild = new List<string> { "guildcmd1" };
-            var pages = StaticTextListHelpers.BuildListPages(global, guild);
+            var pages = PaginationHelpers.BuildListPages(global, guild);
             Assert.Single(pages);
         }
 
@@ -59,7 +59,7 @@ namespace MariBot.Core.Tests
         {
             // Create enough commands to exceed 3500 chars
             var cmds = Enumerable.Range(1, 500).Select(i => $"command{i:D4}").ToList();
-            var pages = StaticTextListHelpers.BuildListPages(cmds, new List<string>());
+            var pages = PaginationHelpers.BuildListPages(cmds, new List<string>());
             Assert.True(pages.Count > 1);
         }
 
@@ -68,7 +68,7 @@ namespace MariBot.Core.Tests
         {
             var global = new List<string> { "myglobalcmd" };
             var guild = new List<string> { "myguildcmd" };
-            var pages = StaticTextListHelpers.BuildListPages(global, guild);
+            var pages = PaginationHelpers.BuildListPages(global, guild);
             var allText = string.Join("", pages.Select(p => p.Description));
             Assert.Contains("myglobalcmd", allText);
             Assert.Contains("Global Commands", allText);
@@ -79,7 +79,7 @@ namespace MariBot.Core.Tests
         {
             var global = new List<string> { "globalcmd" };
             var guild = new List<string> { "myguildcmd" };
-            var pages = StaticTextListHelpers.BuildListPages(global, guild);
+            var pages = PaginationHelpers.BuildListPages(global, guild);
             var allText = string.Join("", pages.Select(p => p.Description));
             Assert.Contains("myguildcmd", allText);
             Assert.Contains("Guild Commands", allText);

--- a/MariBot-Core.Tests/StaticTextResponseServiceTests.cs
+++ b/MariBot-Core.Tests/StaticTextResponseServiceTests.cs
@@ -1,0 +1,208 @@
+using Discord.Commands;
+using Discord.Interactions;
+using Discord.WebSocket;
+using MariBot.Core.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace MariBot.Core.Tests
+{
+    public class StaticTextResponseServiceTests
+    {
+        private static readonly ulong Guild1 = 111111111111111111UL;
+        private static readonly ulong Guild2 = 222222222222222222UL;
+
+        private StaticTextResponseService CreateService()
+        {
+            var dataService = new DataService(NullLogger<DataService>.Instance, ":memory:");
+            var commandService = new CommandService();
+            var discordClient = new DiscordSocketClient(new DiscordSocketConfig { GatewayIntents = Discord.GatewayIntents.None });
+            var interactionService = new InteractionService(discordClient);
+            return new StaticTextResponseService(dataService, commandService, interactionService);
+        }
+
+        // --- Blank validation: AddNewResponse ---
+
+        [Fact]
+        public async Task AddNewResponse_BlankCommandName_ReturnsError()
+        {
+            var service = CreateService();
+            var result = await service.AddNewResponse("   ", "hello", Guild1, null, false);
+            Assert.Equal("Command name cannot be blank.", result);
+        }
+
+        [Fact]
+        public async Task AddNewResponse_BlankTextAndNoAttachments_ReturnsError()
+        {
+            var service = CreateService();
+            var result = await service.AddNewResponse("testcmd", "", Guild1, null, false);
+            Assert.Equal("Response cannot be blank. Provide text or attach a file.", result);
+        }
+
+        [Fact]
+        public async Task AddNewResponse_WhitespaceTextAndNoAttachments_ReturnsError()
+        {
+            var service = CreateService();
+            var result = await service.AddNewResponse("testcmd", "   ", Guild1, null, false);
+            Assert.Equal("Response cannot be blank. Provide text or attach a file.", result);
+        }
+
+        // --- Blank validation: UpdateResponse ---
+
+        [Fact]
+        public async Task UpdateResponse_BlankCommandName_ReturnsError()
+        {
+            var service = CreateService();
+            var result = await service.UpdateResponse("", "hello", Guild1, null, false);
+            Assert.Equal("Command name cannot be blank.", result);
+        }
+
+        [Fact]
+        public async Task UpdateResponse_BlankTextAndNoAttachments_ReturnsError()
+        {
+            var service = CreateService();
+            var result = await service.UpdateResponse("testcmd", "", Guild1, null, false);
+            Assert.Equal("Response cannot be blank. Provide text or attach a file.", result);
+        }
+
+        // --- Duplicate detection ---
+
+        [Fact]
+        public async Task AddNewResponse_DuplicateGuildCommand_ReturnsExplicitAlreadyExistsMessage()
+        {
+            var service = CreateService();
+            await service.AddNewResponse("testcmd", "first", Guild1, null, false);
+            var result = await service.AddNewResponse("testcmd", "second", Guild1, null, false);
+            Assert.Equal("Failed to add command. A guild command with this name already exists.", result);
+        }
+
+        [Fact]
+        public async Task AddNewResponse_DuplicateGlobalCommand_ReturnsExplicitAlreadyExistsMessage()
+        {
+            var service = CreateService();
+            await service.AddNewResponse("globalcmd", "first", Guild1, null, true);
+            var result = await service.AddNewResponse("globalcmd", "second", Guild1, null, true);
+            Assert.Equal("Failed to add command. A global command with this name already exists.", result);
+        }
+
+        // --- Normal add/update ---
+
+        [Fact]
+        public async Task AddNewResponse_ValidGuildCommand_ReturnsOk()
+        {
+            var service = CreateService();
+            var result = await service.AddNewResponse("testcmd", "hello world", Guild1, null, false);
+            Assert.Equal("OK", result);
+        }
+
+        [Fact]
+        public async Task AddNewResponse_ValidGlobalCommand_ReturnsOk()
+        {
+            var service = CreateService();
+            var result = await service.AddNewResponse("globalcmd", "global response", Guild1, null, true);
+            Assert.Equal("OK", result);
+        }
+
+        [Fact]
+        public async Task UpdateResponse_CommandNotYetExisting_CreatesNewEntry()
+        {
+            var service = CreateService();
+            var result = await service.UpdateResponse("newcmd", "new content", Guild1, null, false);
+            Assert.Equal("OK", result);
+            Assert.NotNull(service.GetResponse("newcmd", Guild1));
+        }
+
+        // --- PromoteToGlobal ---
+
+        [Fact]
+        public async Task PromoteToGlobal_HappyPath_ReturnsOk()
+        {
+            var service = CreateService();
+            await service.AddNewResponse("promoteme", "hello", Guild1, null, false);
+            var result = service.PromoteToGlobal("promoteme", Guild1);
+            Assert.Equal("OK", result);
+        }
+
+        [Fact]
+        public async Task PromoteToGlobal_HappyPath_GlobalEntryCreated()
+        {
+            var service = CreateService();
+            await service.AddNewResponse("promoteme", "hello", Guild1, null, false);
+            service.PromoteToGlobal("promoteme", Guild1);
+            var globalEntries = service.GetGlobalResponses();
+            Assert.Contains(globalEntries, r => r.Command.Equals("promoteme", StringComparison.OrdinalIgnoreCase));
+        }
+
+        [Fact]
+        public async Task PromoteToGlobal_HappyPath_GuildEntryRemoved()
+        {
+            var service = CreateService();
+            await service.AddNewResponse("promoteme", "hello", Guild1, null, false);
+            service.PromoteToGlobal("promoteme", Guild1);
+            var guildEntries = service.GetGuildResponses(Guild1);
+            Assert.DoesNotContain(guildEntries, r => r.Command.Equals("promoteme", StringComparison.OrdinalIgnoreCase));
+        }
+
+        [Fact]
+        public void PromoteToGlobal_CommandNotInGuild_ReturnsError()
+        {
+            var service = CreateService();
+            var result = service.PromoteToGlobal("doesnotexist", Guild1);
+            Assert.Equal("Command \"doesnotexist\" not found in this guild's responses.", result);
+        }
+
+        [Fact]
+        public async Task PromoteToGlobal_GlobalAlreadyExists_ReturnsError()
+        {
+            var service = CreateService();
+            await service.AddNewResponse("cmd", "guild version", Guild1, null, false);
+            await service.AddNewResponse("cmd", "global version", Guild1, null, true);
+            var result = service.PromoteToGlobal("cmd", Guild1);
+            Assert.Equal("Failed to promote. A global command named \"cmd\" already exists.", result);
+        }
+
+        [Fact]
+        public async Task PromoteToGlobal_OtherGuildHasSameCommand_ReturnsConflictMessage()
+        {
+            var service = CreateService();
+            await service.AddNewResponse("cmd", "guild1 version", Guild1, null, false);
+            await service.AddNewResponse("cmd", "guild2 version", Guild2, null, false);
+            var result = service.PromoteToGlobal("cmd", Guild1);
+            Assert.StartsWith("Failed to promote. Other guilds have the same command:", result);
+            Assert.Contains(Guild2.ToString(), result);
+        }
+
+        // --- Filtering helpers ---
+
+        [Fact]
+        public async Task GetGlobalResponses_ReturnsOnlyGlobalEntries()
+        {
+            var service = CreateService();
+            await service.AddNewResponse("globalcmd", "global", Guild1, null, true);
+            await service.AddNewResponse("guildcmd", "guild", Guild1, null, false);
+            var globals = service.GetGlobalResponses();
+            Assert.All(globals, r => Assert.True(r.IsGlobal));
+            Assert.Contains(globals, r => r.Command.Equals("globalcmd", StringComparison.OrdinalIgnoreCase));
+        }
+
+        [Fact]
+        public async Task GetGuildResponses_ReturnsOnlyMatchingGuildEntries()
+        {
+            var service = CreateService();
+            await service.AddNewResponse("g1cmd", "for guild1", Guild1, null, false);
+            await service.AddNewResponse("g2cmd", "for guild2", Guild2, null, false);
+            var guild1Entries = service.GetGuildResponses(Guild1);
+            Assert.All(guild1Entries, r => Assert.Equal(Guild1, r.GuildId));
+            Assert.Contains(guild1Entries, r => r.Command.Equals("g1cmd", StringComparison.OrdinalIgnoreCase));
+        }
+
+        [Fact]
+        public async Task GetGuildResponses_DoesNotReturnOtherGuildsEntries()
+        {
+            var service = CreateService();
+            await service.AddNewResponse("g2cmd", "for guild2", Guild2, null, false);
+            var guild1Entries = service.GetGuildResponses(Guild1);
+            Assert.DoesNotContain(guild1Entries, r => r.Command.Equals("g2cmd", StringComparison.OrdinalIgnoreCase));
+        }
+    }
+}

--- a/MariBot-Core/MariBot.Core.csproj
+++ b/MariBot-Core/MariBot.Core.csproj
@@ -29,6 +29,12 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Content Include="Resources\Help\*.md">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="BooruSharp" Version="3.5.5" />
     <PackageReference Include="ByteSize" Version="2.0.0" />
     <PackageReference Include="ConsoleTables" Version="2.4.2" />

--- a/MariBot-Core/MariBot.Core.csproj
+++ b/MariBot-Core/MariBot.Core.csproj
@@ -62,7 +62,7 @@
     <PackageReference Include="UrbanDictionaryDex" Version="1.0.3" />
     <PackageReference Include="WikipediaNet" Version="2.0.0" />
     <PackageReference Include="WolframAlphaNET" Version="2.0.0" />
-    <PackageReference Include="XaiProtoSharp" Version="2026.2.13" />
+    <PackageReference Include="XaiProtoSharp" Version="2026.2.18" />
     <PackageReference Include="YoutubeDLSharp" Version="1.1.1" />
   </ItemGroup>
 

--- a/MariBot-Core/Modules/Text/AiModule.cs
+++ b/MariBot-Core/Modules/Text/AiModule.cs
@@ -1,3 +1,4 @@
+using System.Text.RegularExpressions;
 using Discord;
 using Discord.Commands;
 using MariBot.Core.Services;
@@ -259,6 +260,95 @@ namespace MariBot.Core.Modules.Text
                 var result = await grokService.GetGrokVideoAsync(input, seconds);
                 var stream = await imageService.GetWebResource(result);
                 await Context.Channel.SendFileAsync(stream, "grok_video.mp4",
+                    messageReference: new MessageReference(Context.Message.Id));
+            }
+            catch (Exception ex)
+            {
+                await HandleUnexpectedException(ex);
+            }
+        }
+
+        /// <summary>
+        /// Grok Image Editing Command
+        /// </summary>
+        /// <param name="input">Editing instructions and optional image URLs</param>
+        [Command("grokedit", RunMode = RunMode.Async)]
+        public async Task GrokImageEdit([Remainder] string input)
+        {
+            try
+            {
+                var imageUrls = new List<string>();
+                var prompt = input;
+                var supportedContentTypes = new HashSet<string> { "image/png", "image/jpeg", "image/webp" };
+
+                // Source 1: Direct attachments (up to 2)
+                if (Context.Message.Attachments.Any())
+                {
+                    imageUrls.AddRange(Context.Message.Attachments
+                        .Where(a => a.ContentType != null && supportedContentTypes.Contains(a.ContentType))
+                        .Take(2)
+                        .Select(a => a.Url));
+                }
+
+                // Source 2: Reply attachments/embeds
+                if (!imageUrls.Any() && Context.Message.Reference?.MessageId.IsSpecified == true)
+                {
+                    var referencedMsg = await Context.Channel.GetMessageAsync(Context.Message.Reference.MessageId.Value);
+                    if (referencedMsg != null)
+                    {
+                        imageUrls.AddRange(referencedMsg.Attachments
+                            .Where(a => a.ContentType != null && supportedContentTypes.Contains(a.ContentType))
+                            .Take(2)
+                            .Select(a => a.Url));
+
+                        if (!imageUrls.Any())
+                        {
+                            imageUrls.AddRange(referencedMsg.Embeds
+                                .Where(e => e.Image.HasValue)
+                                .Take(2)
+                                .Select(e => e.Image.Value.Url));
+                        }
+                    }
+                }
+
+                // Source 3: URLs in message content
+                if (!imageUrls.Any())
+                {
+                    var urlPattern = new Regex(@"https?://\S+\.(?:png|jpe?g|webp)(?:\?\S*)?", RegexOptions.IgnoreCase);
+                    var matches = urlPattern.Matches(input);
+                    foreach (Match match in matches.Take(2))
+                    {
+                        imageUrls.Add(match.Value);
+                        prompt = prompt.Replace(match.Value, "").Trim();
+                    }
+                }
+
+                // Source 4: Channel history fallback (1 image)
+                if (!imageUrls.Any() && Context is Discord.Commands.SocketCommandContext socketContext)
+                {
+                    var historyUrl = await imageService.GetImageUrl(socketContext);
+                    if (historyUrl != null)
+                    {
+                        imageUrls.Add(historyUrl);
+                    }
+                }
+
+                // Grok API accepts at most 2 images
+                if (imageUrls.Count > 2)
+                {
+                    imageUrls = imageUrls.Take(2).ToList();
+                }
+
+                if (!imageUrls.Any())
+                {
+                    await Context.Channel.SendMessageAsync("Please provide at least one image to edit.",
+                        messageReference: new MessageReference(Context.Message.Id));
+                    return;
+                }
+
+                var result = await grokService.GetGrokImageEditAsync(prompt, imageUrls);
+                var stream = await imageService.GetWebResource(result);
+                await Context.Channel.SendFileAsync(stream, "grok_edit.png",
                     messageReference: new MessageReference(Context.Message.Id));
             }
             catch (Exception ex)

--- a/MariBot-Core/Modules/Text/AiModule.cs
+++ b/MariBot-Core/Modules/Text/AiModule.cs
@@ -2,6 +2,7 @@ using System.Text.RegularExpressions;
 using Discord;
 using Discord.Commands;
 using MariBot.Core.Services;
+using MariBot.Core.Utils;
 using RestSharp.Extensions;
 
 namespace MariBot.Core.Modules.Text
@@ -116,8 +117,7 @@ namespace MariBot.Core.Modules.Text
             {
                 var result =
                     await openAiService.ExecuteGptQuery(input, Context.User.Id.ToString(), Models.OpenAiModel.GPT3);
-                await Context.Channel.SendMessageAsync($"```\n{result.Replace("```", "")}\n```",
-                    messageReference: new MessageReference(Context.Message.Id));
+                await SendCodeBlockResponse(result);
             }
             catch (Exception ex)
             {
@@ -137,8 +137,7 @@ namespace MariBot.Core.Modules.Text
             {
                 var result =
                     await openAiService.ExecuteGptQuery(input, Context.User.Id.ToString(), Models.OpenAiModel.GPT4);
-                await Context.Channel.SendMessageAsync($"```\n{result.Replace("```", "")}\n```",
-                    messageReference: new MessageReference(Context.Message.Id));
+                await SendCodeBlockResponse(result);
             }
             catch (Exception ex)
             {
@@ -159,8 +158,7 @@ namespace MariBot.Core.Modules.Text
             {
                 var result =
                     await openAiService.ExecuteGptQuery(input, Context.User.Id.ToString(), Models.OpenAiModel.GPT5);
-                await Context.Channel.SendMessageAsync($"```\n{result.Replace("```", "")}\n```",
-                    messageReference: new MessageReference(Context.Message.Id));
+                await SendCodeBlockResponse(result);
             }
             catch (Exception ex)
             {
@@ -205,13 +203,7 @@ namespace MariBot.Core.Modules.Text
             try
             {
                 var result = await grokService.GetGrokResponseAsync(input);
-                // Trim result to not be more than 1990 characters to avoid Discord message length limits
-                if (result.Length > 1990)
-                {
-                    result = result.Substring(0, 1990);
-                }
-                await Context.Channel.SendMessageAsync($"```\n{result.Replace("```", "")}\n```",
-                    messageReference: new MessageReference(Context.Message.Id));
+                await SendCodeBlockResponse(result);
             }
             catch (Exception ex)
             {
@@ -354,6 +346,16 @@ namespace MariBot.Core.Modules.Text
             catch (Exception ex)
             {
                 await HandleUnexpectedException(ex);
+            }
+        }
+
+        private async Task SendCodeBlockResponse(string text)
+        {
+            var chunks = PaginationHelpers.ChunkText(text.Replace("```", ""), 1992);
+            foreach (var chunk in chunks)
+            {
+                await Context.Channel.SendMessageAsync($"```\n{chunk}\n```",
+                    messageReference: new MessageReference(Context.Message.Id));
             }
         }
 

--- a/MariBot-Core/Modules/Text/InfoModule.cs
+++ b/MariBot-Core/Modules/Text/InfoModule.cs
@@ -1,29 +1,68 @@
-﻿using Discord.Commands;
+using Discord;
+using Discord.Commands;
+using MariBot.Core.Utils;
 
 namespace MariBot.Core.Modules.Text
 {
     public class InfoModule : ModuleBase<SocketCommandContext>
     {
+        private readonly CommandService _commands;
+
+        public InfoModule(CommandService commands)
+        {
+            _commands = commands;
+        }
+
         [Command("info")]
         public Task Info()
             => ReplyAsync(
                 $"Hello, I am a bot called {Context.Client.CurrentUser.Username} written in Discord.Net\n");
 
         [Command("help")]
-        public Task Help()
+        public async Task Help()
         {
-            // TODO: Rewrite this to not rely on web-hosted docs
-            if (Context.Guild.Id == 297485054836342786) // Server is prohibited from using some commands
+            var commands = _commands.Commands
+                .SelectMany(c => c.Aliases)
+                .Select(a => a.Split(' ')[0].ToLowerInvariant())
+                .ToHashSet()
+                .OrderBy(n => n)
+                .ToList();
+
+            var text = "**Available Commands:**\n" + string.Join(", ", commands);
+            var chunks = PaginationHelpers.ChunkText(text, 3500);
+            int page = 1;
+            foreach (var chunk in chunks)
             {
-                return ReplyAsync("https://dsdude123.github.io/MariBot/297485054836342786/commands.html");
+                var eb = new EmbedBuilder()
+                    .WithTitle($"Commands (Page {page++} of {chunks.Count})")
+                    .WithDescription(chunk)
+                    .WithColor(Color.Blue);
+                await ReplyAsync(embed: eb.Build());
             }
-            else if (Context.Guild.Id == 564645677586710548)
+        }
+
+        [Command("help")]
+        public async Task Help([Remainder] string commandName)
+        {
+            var path = Path.Combine(AppDomain.CurrentDomain.BaseDirectory,
+                "Resources", "Help", $"{commandName.ToLower().Trim()}.md");
+
+            if (!File.Exists(path))
             {
-                return ReplyAsync("https://dsdude123.github.io/MariBot/564645677586710548/commands.html");
+                await ReplyAsync($"No help file found for command: `{commandName}`");
+                return;
             }
-            else
+
+            var content = File.ReadAllText(path);
+            var chunks = PaginationHelpers.ChunkText(content, 3500);
+            int page = 1;
+            foreach (var chunk in chunks)
             {
-                return ReplyAsync("https://dsdude123.github.io/MariBot/commands.html");
+                var eb = new EmbedBuilder()
+                    .WithTitle($"{commandName} Help (Page {page++} of {chunks.Count})")
+                    .WithDescription(chunk)
+                    .WithColor(Color.Blue);
+                await ReplyAsync(embed: eb.Build());
             }
         }
     }

--- a/MariBot-Core/Modules/Text/StaticTextListHelpers.cs
+++ b/MariBot-Core/Modules/Text/StaticTextListHelpers.cs
@@ -1,0 +1,50 @@
+using Discord;
+
+namespace MariBot.Core.Modules.Text
+{
+    public static class StaticTextListHelpers
+    {
+        private const int MaxDescriptionLength = 3500;
+
+        public static List<Embed> BuildListPages(List<string> globalCmds, List<string> guildCmds)
+        {
+            var pages = new List<Embed>();
+
+            var globalSection = globalCmds.Count > 0
+                ? "**Global Commands:**\n" + string.Join(", ", globalCmds)
+                : "**Global Commands:**\nNone";
+            var guildSection = guildCmds.Count > 0
+                ? "**Guild Commands:**\n" + string.Join(", ", guildCmds)
+                : "**Guild Commands:**\nNone";
+
+            var fullText = globalSection + "\n\n" + guildSection;
+            var chunks = ChunkText(fullText, MaxDescriptionLength);
+            int pageNum = 1;
+
+            foreach (var chunk in chunks)
+            {
+                var eb = new EmbedBuilder()
+                    .WithTitle($"Static Text Commands (Page {pageNum++} of {chunks.Count})")
+                    .WithDescription(chunk)
+                    .WithColor(Color.Blue);
+                pages.Add(eb.Build());
+            }
+
+            return pages;
+        }
+
+        public static List<string> ChunkText(string text, int maxLength)
+        {
+            var chunks = new List<string>();
+            while (text.Length > maxLength)
+            {
+                int cut = text.LastIndexOf('\n', maxLength);
+                if (cut < 0) cut = maxLength;
+                chunks.Add(text[..cut]);
+                text = text[cut..].TrimStart('\n');
+            }
+            if (text.Length > 0) chunks.Add(text);
+            return chunks;
+        }
+    }
+}

--- a/MariBot-Core/Modules/Text/StaticTextManagerModule.cs
+++ b/MariBot-Core/Modules/Text/StaticTextManagerModule.cs
@@ -1,6 +1,7 @@
 ﻿using Discord;
 using Discord.Commands;
 using MariBot.Core.Services;
+using MariBot.Core.Utils;
 
 namespace MariBot.Core.Modules.Text
 {
@@ -166,7 +167,7 @@ namespace MariBot.Core.Modules.Text
                 .OrderBy(n => n)
                 .ToList();
 
-            var pages = StaticTextListHelpers.BuildListPages(globalCmds, guildCmds);
+            var pages = PaginationHelpers.BuildListPages(globalCmds, guildCmds);
             foreach (var embed in pages)
                 await Context.Channel.SendMessageAsync(embed: embed);
         }

--- a/MariBot-Core/Modules/Text/StaticTextManagerModule.cs
+++ b/MariBot-Core/Modules/Text/StaticTextManagerModule.cs
@@ -1,4 +1,5 @@
-﻿using Discord.Commands;
+﻿using Discord;
+using Discord.Commands;
 using MariBot.Core.Services;
 
 namespace MariBot.Core.Modules.Text
@@ -66,7 +67,7 @@ namespace MariBot.Core.Modules.Text
 
         [RequireOwner]
         [Command("updateglobal", RunMode = RunMode.Async)]
-        public async Task updateGlobal(string key, [Remainder] string text)
+        public async Task updateGlobal(string key, [Remainder] string text = "")
         {
             try
             {
@@ -81,7 +82,7 @@ namespace MariBot.Core.Modules.Text
         }
 
         [Command("update", RunMode = RunMode.Async)]
-        public async Task update(string key, [Remainder] string text)
+        public async Task update(string key, [Remainder] string text = "")
         {
             try
             {
@@ -143,6 +144,31 @@ namespace MariBot.Core.Modules.Text
         public async Task Upgrade()
         {
             await Context.Channel.SendMessageAsync(staticTextResponseService.UpgradeAttachments().Result);
+        }
+
+        [RequireOwner]
+        [Command("promote")]
+        public Task promote(string key)
+        {
+            var result = staticTextResponseService.PromoteToGlobal(key, Context.Guild.Id);
+            return Context.Channel.SendMessageAsync(result);
+        }
+
+        [Command("list", RunMode = RunMode.Async)]
+        public async Task list()
+        {
+            var globalCmds = staticTextResponseService.GetGlobalResponses()
+                .Select(r => r.Command)
+                .OrderBy(n => n)
+                .ToList();
+            var guildCmds = staticTextResponseService.GetGuildResponses(Context.Guild.Id)
+                .Select(r => r.Command)
+                .OrderBy(n => n)
+                .ToList();
+
+            var pages = StaticTextListHelpers.BuildListPages(globalCmds, guildCmds);
+            foreach (var embed in pages)
+                await Context.Channel.SendMessageAsync(embed: embed);
         }
     }
 }

--- a/MariBot-Core/Resources/Help/9gag.md
+++ b/MariBot-Core/Resources/Help/9gag.md
@@ -1,0 +1,9 @@
+# 9gag
+
+Apply a 9GAG watermark.
+
+Provide an image by attaching a file to your message, pasting an image URL in your message,
+or replying to a message that contains an image. You can also mention a user (`@username`)
+to use their avatar.
+
+Run `z 9gag`.

--- a/MariBot-Core/Resources/Help/adidas.md
+++ b/MariBot-Core/Resources/Help/adidas.md
@@ -1,0 +1,9 @@
+# adidas
+
+Apply an Adidas logo overlay.
+
+Provide an image by attaching a file to your message, pasting an image URL in your message,
+or replying to a message that contains an image. You can also mention a user (`@username`)
+to use their avatar.
+
+Run `z adidas`.

--- a/MariBot-Core/Resources/Help/adw.md
+++ b/MariBot-Core/Resources/Help/adw.md
@@ -1,0 +1,9 @@
+# adw
+
+Apply the Admin Walk meme template.
+
+Provide an image by attaching a file to your message, pasting an image URL in your message,
+or replying to a message that contains an image. You can also mention a user (`@username`)
+to use their avatar.
+
+Run `z adw`.

--- a/MariBot-Core/Resources/Help/aew.md
+++ b/MariBot-Core/Resources/Help/aew.md
@@ -1,0 +1,9 @@
+# aew
+
+Apply the AEW wrestling meme template.
+
+Provide an image by attaching a file to your message, pasting an image URL in your message,
+or replying to a message that contains an image. You can also mention a user (`@username`)
+to use their avatar.
+
+Run `z aew`.

--- a/MariBot-Core/Resources/Help/ai-image.md
+++ b/MariBot-Core/Resources/Help/ai-image.md
@@ -1,0 +1,7 @@
+# ai-image
+
+Generate an image from a text prompt using Stable Diffusion.
+
+**Usage:** `z ai-image <prompt>`
+
+Processed by the Worker service — may take a moment to complete.

--- a/MariBot-Core/Resources/Help/ai-pokemon.md
+++ b/MariBot-Core/Resources/Help/ai-pokemon.md
@@ -1,0 +1,7 @@
+# ai-pokemon
+
+Generate a Pokémon-style image from a text prompt using Stable Diffusion.
+
+**Usage:** `z ai-pokemon <prompt>`
+
+Processed by the Worker service — may take a moment to complete.

--- a/MariBot-Core/Resources/Help/ai-waifu.md
+++ b/MariBot-Core/Resources/Help/ai-waifu.md
@@ -1,0 +1,7 @@
+# ai-waifu
+
+Generate a waifu-style image from a text prompt using Stable Diffusion.
+
+**Usage:** `z ai-waifu <prompt>`
+
+Processed by the Worker service — may take a moment to complete.

--- a/MariBot-Core/Resources/Help/ajit.md
+++ b/MariBot-Core/Resources/Help/ajit.md
@@ -1,0 +1,9 @@
+# ajit
+
+Apply the Ajit Pai meme template.
+
+Provide an image by attaching a file to your message, pasting an image URL in your message,
+or replying to a message that contains an image. You can also mention a user (`@username`)
+to use their avatar.
+
+Run `z ajit`.

--- a/MariBot-Core/Resources/Help/america.md
+++ b/MariBot-Core/Resources/Help/america.md
@@ -1,0 +1,9 @@
+# america
+
+Apply the America meme template.
+
+Provide an image by attaching a file to your message, pasting an image URL in your message,
+or replying to a message that contains an image. You can also mention a user (`@username`)
+to use their avatar.
+
+Run `z america`.

--- a/MariBot-Core/Resources/Help/analysis.md
+++ b/MariBot-Core/Resources/Help/analysis.md
@@ -1,0 +1,9 @@
+# analysis
+
+Apply the Analysis meme template.
+
+Provide an image by attaching a file to your message, pasting an image URL in your message,
+or replying to a message that contains an image. You can also mention a user (`@username`)
+to use their avatar.
+
+Run `z analysis`.

--- a/MariBot-Core/Resources/Help/andrew.md
+++ b/MariBot-Core/Resources/Help/andrew.md
@@ -1,0 +1,10 @@
+# andrew
+
+Apply the Andrew meme template. Picks a random variant from 2 available options.
+
+Provide an image by attaching a file to your message, pasting an image URL in your message,
+or replying to a message that contains an image. You can also mention a user (`@username`)
+to use their avatar.
+
+Run `z andrew [number]`. To select a specific variant, add its number
+(e.g., `z andrew 2`). Valid range: 1–2.

--- a/MariBot-Core/Resources/Help/asuka.md
+++ b/MariBot-Core/Resources/Help/asuka.md
@@ -1,0 +1,9 @@
+# asuka
+
+Apply the Asuka meme template.
+
+Provide an image by attaching a file to your message, pasting an image URL in your message,
+or replying to a message that contains an image. You can also mention a user (`@username`)
+to use their avatar.
+
+Run `z asuka`.

--- a/MariBot-Core/Resources/Help/austin.md
+++ b/MariBot-Core/Resources/Help/austin.md
@@ -1,0 +1,9 @@
+# austin
+
+Apply the Austin meme template.
+
+Provide an image by attaching a file to your message, pasting an image URL in your message,
+or replying to a message that contains an image. You can also mention a user (`@username`)
+to use their avatar.
+
+Run `z austin`.

--- a/MariBot-Core/Resources/Help/banner.md
+++ b/MariBot-Core/Resources/Help/banner.md
@@ -1,0 +1,5 @@
+# banner
+
+Generate a "Hang the Banner" meme with custom text.
+
+**Usage:** `z banner <text>`

--- a/MariBot-Core/Resources/Help/bernie.md
+++ b/MariBot-Core/Resources/Help/bernie.md
@@ -1,0 +1,9 @@
+# bernie
+
+Apply the Bernie Sanders meme template.
+
+Provide an image by attaching a file to your message, pasting an image URL in your message,
+or replying to a message that contains an image. You can also mention a user (`@username`)
+to use their avatar.
+
+Run `z bernie`.

--- a/MariBot-Core/Resources/Help/biden.md
+++ b/MariBot-Core/Resources/Help/biden.md
@@ -1,0 +1,10 @@
+# biden
+
+Apply the Biden meme template. Picks a random variant from 4 available options.
+
+Provide an image by attaching a file to your message, pasting an image URL in your message,
+or replying to a message that contains an image. You can also mention a user (`@username`)
+to use their avatar.
+
+Run `z biden [number]`. To select a specific variant, add its number
+(e.g., `z biden 2`). Valid range: 1–4.

--- a/MariBot-Core/Resources/Help/binoculars.md
+++ b/MariBot-Core/Resources/Help/binoculars.md
@@ -1,0 +1,9 @@
+# binoculars
+
+Apply the Binoculars meme template.
+
+Provide an image by attaching a file to your message, pasting an image URL in your message,
+or replying to a message that contains an image. You can also mention a user (`@username`)
+to use their avatar.
+
+Run `z binoculars`.

--- a/MariBot-Core/Resources/Help/blagblare.md
+++ b/MariBot-Core/Resources/Help/blagblare.md
@@ -1,0 +1,9 @@
+# blagblare
+
+Apply the Blagblare meme template.
+
+Provide an image by attaching a file to your message, pasting an image URL in your message,
+or replying to a message that contains an image. You can also mention a user (`@username`)
+to use their avatar.
+
+Run `z blagblare`.

--- a/MariBot-Core/Resources/Help/bobross.md
+++ b/MariBot-Core/Resources/Help/bobross.md
@@ -1,0 +1,9 @@
+# bobross
+
+Apply the Bob Ross meme template.
+
+Provide an image by attaching a file to your message, pasting an image URL in your message,
+or replying to a message that contains an image. You can also mention a user (`@username`)
+to use their avatar.
+
+Run `z bobross`.

--- a/MariBot-Core/Resources/Help/classic.md
+++ b/MariBot-Core/Resources/Help/classic.md
@@ -1,0 +1,9 @@
+# classic
+
+Apply the Classic meme template.
+
+Provide an image by attaching a file to your message, pasting an image URL in your message,
+or replying to a message that contains an image. You can also mention a user (`@username`)
+to use their avatar.
+
+Run `z classic`.

--- a/MariBot-Core/Resources/Help/cmm.md
+++ b/MariBot-Core/Resources/Help/cmm.md
@@ -1,0 +1,5 @@
+# cmm
+
+Generate a "Change My Mind" meme with custom text.
+
+**Usage:** `z cmm <text>`

--- a/MariBot-Core/Resources/Help/comic.md
+++ b/MariBot-Core/Resources/Help/comic.md
@@ -1,0 +1,9 @@
+# comic
+
+Fetch a random comic strip from various webcomics.
+
+## Commands
+
+- `z comic cyanide` — Posts a random **Cyanide and Happiness** comic.
+- `z comic xkcd` — Posts a random **XKCD** comic.
+- `z comic lovenstein` — Posts a random **Mr. Lovenstein** comic.

--- a/MariBot-Core/Resources/Help/condom.md
+++ b/MariBot-Core/Resources/Help/condom.md
@@ -1,0 +1,9 @@
+# condom
+
+Apply the Condom meme template.
+
+Provide an image by attaching a file to your message, pasting an image URL in your message,
+or replying to a message that contains an image. You can also mention a user (`@username`)
+to use their avatar.
+
+Run `z condom`.

--- a/MariBot-Core/Resources/Help/dalle.md
+++ b/MariBot-Core/Resources/Help/dalle.md
@@ -1,0 +1,7 @@
+# dalle
+
+Generate an image using DALL-E.
+
+**Usage:** `z dalle <prompt>`
+
+Also available as `z dallehd`.

--- a/MariBot-Core/Resources/Help/dallehd.md
+++ b/MariBot-Core/Resources/Help/dallehd.md
@@ -1,0 +1,5 @@
+# dallehd
+
+Generate an image using DALL-E. Alias for `z dalle`.
+
+**Usage:** `z dallehd <prompt>`

--- a/MariBot-Core/Resources/Help/danbooru.md
+++ b/MariBot-Core/Resources/Help/danbooru.md
@@ -1,0 +1,12 @@
+# danbooru
+
+Fetch a random image from Danbooru.
+
+## Usage
+
+`z danbooru [tags]`
+
+## Notes
+
+- Tags are optional and space-separated (e.g., `z danbooru landscape sky`).
+- *NSFW — only works in NSFW-designated channels.*

--- a/MariBot-Core/Resources/Help/daryl.md
+++ b/MariBot-Core/Resources/Help/daryl.md
@@ -1,0 +1,10 @@
+# daryl
+
+Apply the Daryl meme template. Picks a random variant from 10 available options.
+
+Provide an image by attaching a file to your message, pasting an image URL in your message,
+or replying to a message that contains an image. You can also mention a user (`@username`)
+to use their avatar.
+
+Run `z daryl [number]`. To select a specific variant, add its number
+(e.g., `z daryl 3`). Valid range: 1–10.

--- a/MariBot-Core/Resources/Help/dave.md
+++ b/MariBot-Core/Resources/Help/dave.md
@@ -1,0 +1,9 @@
+# dave
+
+Apply the Dave meme template.
+
+Provide an image by attaching a file to your message, pasting an image URL in your message,
+or replying to a message that contains an image. You can also mention a user (`@username`)
+to use their avatar.
+
+Run `z dave`.

--- a/MariBot-Core/Resources/Help/deepfry.md
+++ b/MariBot-Core/Resources/Help/deepfry.md
@@ -1,0 +1,9 @@
+# deepfry
+
+Apply a deep fry distortion effect.
+
+Provide an image by attaching a file to your message, pasting an image URL in your message,
+or replying to a message that contains an image. You can also mention a user (`@username`)
+to use their avatar.
+
+Run `z deepfry`.

--- a/MariBot-Core/Resources/Help/dkoldies.md
+++ b/MariBot-Core/Resources/Help/dkoldies.md
@@ -1,0 +1,9 @@
+# dkoldies
+
+Apply a DK Oldies logo overlay.
+
+Provide an image by attaching a file to your message, pasting an image URL in your message,
+or replying to a message that contains an image. You can also mention a user (`@username`)
+to use their avatar.
+
+Run `z dkoldies`.

--- a/MariBot-Core/Resources/Help/downloadvideo.md
+++ b/MariBot-Core/Resources/Help/downloadvideo.md
@@ -1,0 +1,5 @@
+# downloadvideo
+
+Download a video from a URL and post it.
+
+**Usage:** `z downloadvideo <url>`

--- a/MariBot-Core/Resources/Help/dskoopa.md
+++ b/MariBot-Core/Resources/Help/dskoopa.md
@@ -1,0 +1,9 @@
+# dskoopa
+
+Apply the DS Koopa meme template.
+
+Provide an image by attaching a file to your message, pasting an image URL in your message,
+or replying to a message that contains an image. You can also mention a user (`@username`)
+to use their avatar.
+
+Run `z dskoopa`.

--- a/MariBot-Core/Resources/Help/e2h.md
+++ b/MariBot-Core/Resources/Help/e2h.md
@@ -1,0 +1,9 @@
+# e2h
+
+Apply an edges-to-hentai conversion.
+
+Provide an image by attaching a file to your message, pasting an image URL in your message,
+or replying to a message that contains an image. You can also mention a user (`@username`)
+to use their avatar.
+
+Run `z e2h`.

--- a/MariBot-Core/Resources/Help/expert.md
+++ b/MariBot-Core/Resources/Help/expert.md
@@ -1,0 +1,9 @@
+# expert
+
+Apply the Expert Analysis meme template.
+
+Provide an image by attaching a file to your message, pasting an image URL in your message,
+or replying to a message that contains an image. You can also mention a user (`@username`)
+to use their avatar.
+
+Run `z expert`.

--- a/MariBot-Core/Resources/Help/fantasy.md
+++ b/MariBot-Core/Resources/Help/fantasy.md
@@ -1,0 +1,11 @@
+# fantasy
+
+Yahoo Fantasy Sports integration.
+
+## Commands
+
+- `z fantasy league` — Display information about the current fantasy league.
+- `z fantasy standings` — Display the league standings for the current week.
+- `z fantasy scoreboard` — Display current and projected scores for all matchups.
+- `z fantasy authenticate [code]` — Authenticate with Yahoo Fantasy Sports. Run without a code first to receive the authorization link, then re-run with the provided code.
+- `z fantasy raw <url>` — Fetch a raw API response from a Yahoo Fantasy Sports endpoint.

--- a/MariBot-Core/Resources/Help/flipcoin.md
+++ b/MariBot-Core/Resources/Help/flipcoin.md
@@ -1,0 +1,5 @@
+# flipcoin
+
+Flip a coin and get heads or tails.
+
+**Usage:** `z flipcoin`

--- a/MariBot-Core/Resources/Help/flux.md
+++ b/MariBot-Core/Resources/Help/flux.md
@@ -1,0 +1,5 @@
+# flux
+
+Generate an image using Black Forest Labs Flux.
+
+**Usage:** `z flux <prompt>`

--- a/MariBot-Core/Resources/Help/gelbooru.md
+++ b/MariBot-Core/Resources/Help/gelbooru.md
@@ -1,0 +1,12 @@
+# gelbooru
+
+Fetch a random image from Gelbooru.
+
+## Usage
+
+`z gelbooru [tags]`
+
+## Notes
+
+- Tags are optional and space-separated (e.g., `z gelbooru landscape sky`).
+- *NSFW — only works in NSFW-designated channels.*

--- a/MariBot-Core/Resources/Help/google.md
+++ b/MariBot-Core/Resources/Help/google.md
@@ -1,0 +1,5 @@
+# google
+
+Show Google search results.
+
+**Usage:** `z google <keywords>`

--- a/MariBot-Core/Resources/Help/gpt.md
+++ b/MariBot-Core/Resources/Help/gpt.md
@@ -1,0 +1,5 @@
+# gpt
+
+Generate a text response using GPT-5. Alias for `z gpt5`.
+
+**Usage:** `z gpt <prompt>`

--- a/MariBot-Core/Resources/Help/gpt3.md
+++ b/MariBot-Core/Resources/Help/gpt3.md
@@ -1,0 +1,5 @@
+# gpt3
+
+Generate a text response using GPT-3.
+
+**Usage:** `z gpt3 <prompt>`

--- a/MariBot-Core/Resources/Help/gpt4.md
+++ b/MariBot-Core/Resources/Help/gpt4.md
@@ -1,0 +1,5 @@
+# gpt4
+
+Generate a text response using GPT-4.
+
+**Usage:** `z gpt4 <prompt>`

--- a/MariBot-Core/Resources/Help/gpt5.md
+++ b/MariBot-Core/Resources/Help/gpt5.md
@@ -1,0 +1,7 @@
+# gpt5
+
+Generate a text response using GPT-5.
+
+**Usage:** `z gpt5 <prompt>`
+
+Also available as `z gpt`.

--- a/MariBot-Core/Resources/Help/gptimage.md
+++ b/MariBot-Core/Resources/Help/gptimage.md
@@ -1,0 +1,5 @@
+# gptimage
+
+Generate an image using the GPT image model.
+
+**Usage:** `z gptimage <prompt>`

--- a/MariBot-Core/Resources/Help/grok.md
+++ b/MariBot-Core/Resources/Help/grok.md
@@ -1,0 +1,5 @@
+# grok
+
+Generate a text response using Grok.
+
+**Usage:** `z grok <prompt>`

--- a/MariBot-Core/Resources/Help/grokedit.md
+++ b/MariBot-Core/Resources/Help/grokedit.md
@@ -1,0 +1,11 @@
+# grokedit
+
+Edit an image using Grok. Provide 1-2 images along with editing instructions.
+
+**Usage:** `z grokedit <prompt>`
+
+**Image input methods (checked in priority order):**
+1. Attach 1-2 images directly to your message
+2. Reply to a message that contains an image
+3. Include image URLs in your message text
+4. Post an image in the channel, then run the command (uses most recent image)

--- a/MariBot-Core/Resources/Help/grokimage.md
+++ b/MariBot-Core/Resources/Help/grokimage.md
@@ -1,0 +1,5 @@
+# grokimage
+
+Generate an image using Grok.
+
+**Usage:** `z grokimage <prompt>`

--- a/MariBot-Core/Resources/Help/grokvideo.md
+++ b/MariBot-Core/Resources/Help/grokvideo.md
@@ -1,0 +1,7 @@
+# grokvideo
+
+Generate a video using Grok. *(Owner only)*
+
+**Usage:** `z grokvideo <seconds> <prompt>`
+
+- `seconds` — Video duration in seconds (1–10).

--- a/MariBot-Core/Resources/Help/herschel.md
+++ b/MariBot-Core/Resources/Help/herschel.md
@@ -1,0 +1,9 @@
+# herschel
+
+Apply the Herschel meme template.
+
+Provide an image by attaching a file to your message, pasting an image URL in your message,
+or replying to a message that contains an image. You can also mention a user (`@username`)
+to use their avatar.
+
+Run `z herschel`.

--- a/MariBot-Core/Resources/Help/image.md
+++ b/MariBot-Core/Resources/Help/image.md
@@ -1,0 +1,5 @@
+# image
+
+Show Google Images results.
+
+**Usage:** `z image <keywords>`

--- a/MariBot-Core/Resources/Help/jfk.md
+++ b/MariBot-Core/Resources/Help/jfk.md
@@ -1,0 +1,5 @@
+# jfk
+
+Speak text in the voice of JFK.
+
+**Usage:** `z jfk <text>`

--- a/MariBot-Core/Resources/Help/johnriggs.md
+++ b/MariBot-Core/Resources/Help/johnriggs.md
@@ -1,0 +1,9 @@
+# johnriggs
+
+Apply the John Riggs meme template.
+
+Provide an image by attaching a file to your message, pasting an image URL in your message,
+or replying to a message that contains an image. You can also mention a user (`@username`)
+to use their avatar.
+
+Run `z johnriggs`.

--- a/MariBot-Core/Resources/Help/kamala.md
+++ b/MariBot-Core/Resources/Help/kamala.md
@@ -1,0 +1,9 @@
+# kamala
+
+Apply the Kamala Harris meme template.
+
+Provide an image by attaching a file to your message, pasting an image URL in your message,
+or replying to a message that contains an image. You can also mention a user (`@username`)
+to use their avatar.
+
+Run `z kamala`.

--- a/MariBot-Core/Resources/Help/kevin.md
+++ b/MariBot-Core/Resources/Help/kevin.md
@@ -1,0 +1,10 @@
+# kevin
+
+Apply the Kevin meme template. Picks a random variant from 2 available options.
+
+Provide an image by attaching a file to your message, pasting an image URL in your message,
+or replying to a message that contains an image. You can also mention a user (`@username`)
+to use their avatar.
+
+Run `z kevin [number]`. To select a specific variant, add its number
+(e.g., `z kevin 2`). Valid range: 1–2.

--- a/MariBot-Core/Resources/Help/kg.md
+++ b/MariBot-Core/Resources/Help/kg.md
@@ -1,0 +1,5 @@
+# kg
+
+Search the Google Knowledge Graph and display a summary card.
+
+**Usage:** `z kg <keywords>`

--- a/MariBot-Core/Resources/Help/kingportrait.md
+++ b/MariBot-Core/Resources/Help/kingportrait.md
@@ -1,0 +1,9 @@
+# kingportrait
+
+Apply the King Portrait meme template.
+
+Provide an image by attaching a file to your message, pasting an image URL in your message,
+or replying to a message that contains an image. You can also mention a user (`@username`)
+to use their avatar.
+
+Run `z kingportrait`.

--- a/MariBot-Core/Resources/Help/konachan.md
+++ b/MariBot-Core/Resources/Help/konachan.md
@@ -1,0 +1,12 @@
+# konachan
+
+Fetch a random image from Konachan.
+
+## Usage
+
+`z konachan [tags]`
+
+## Notes
+
+- Tags are optional and space-separated (e.g., `z konachan landscape sky`).
+- *NSFW — only works in NSFW-designated channels.*

--- a/MariBot-Core/Resources/Help/kurisu.md
+++ b/MariBot-Core/Resources/Help/kurisu.md
@@ -1,0 +1,5 @@
+# kurisu
+
+Generate a Kurisu character image with custom text.
+
+**Usage:** `z kurisu <text>`

--- a/MariBot-Core/Resources/Help/latex.md
+++ b/MariBot-Core/Resources/Help/latex.md
@@ -1,0 +1,5 @@
+# latex
+
+Render a LaTeX formula as an image.
+
+**Usage:** `z latex <formula>`

--- a/MariBot-Core/Resources/Help/madden.md
+++ b/MariBot-Core/Resources/Help/madden.md
@@ -1,0 +1,5 @@
+# madden
+
+Speak text in the voice of John Madden.
+
+**Usage:** `z madden <text>`

--- a/MariBot-Core/Resources/Help/makoto.md
+++ b/MariBot-Core/Resources/Help/makoto.md
@@ -1,0 +1,9 @@
+# makoto
+
+Apply the Makoto meme template.
+
+Provide an image by attaching a file to your message, pasting an image URL in your message,
+or replying to a message that contains an image. You can also mention a user (`@username`)
+to use their avatar.
+
+Run `z makoto`.

--- a/MariBot-Core/Resources/Help/miyamoto.md
+++ b/MariBot-Core/Resources/Help/miyamoto.md
@@ -1,0 +1,9 @@
+# miyamoto
+
+Apply the Miyamoto meme template.
+
+Provide an image by attaching a file to your message, pasting an image URL in your message,
+or replying to a message that contains an image. You can also mention a user (`@username`)
+to use their avatar.
+
+Run `z miyamoto`.

--- a/MariBot-Core/Resources/Help/mugi.md
+++ b/MariBot-Core/Resources/Help/mugi.md
@@ -1,0 +1,5 @@
+# mugi
+
+Generate a Mugi character image with custom text.
+
+**Usage:** `z mugi <text>`

--- a/MariBot-Core/Resources/Help/nuke.md
+++ b/MariBot-Core/Resources/Help/nuke.md
@@ -1,0 +1,12 @@
+# nuke
+
+Apply an extreme deep-fry distortion effect (10× more aggressive than `z deepfry`).
+
+Each pass adds noise, oversaturates colours, applies heavy JPEG compression, and sharpens the
+image. Running 10 passes in sequence produces a severely degraded, heavily artifacted result.
+
+Provide an image by attaching a file to your message, pasting an image URL in your message,
+or replying to a message that contains an image. You can also mention a user (`@username`)
+to use their avatar.
+
+Run `z nuke`.

--- a/MariBot-Core/Resources/Help/obama-tts.md
+++ b/MariBot-Core/Resources/Help/obama-tts.md
@@ -1,0 +1,5 @@
+# obama-tts
+
+Speak text in the voice of Barack Obama.
+
+**Usage:** `z obama-tts <text>`

--- a/MariBot-Core/Resources/Help/obama.md
+++ b/MariBot-Core/Resources/Help/obama.md
@@ -1,0 +1,10 @@
+# obama
+
+Apply the Obama meme template. Picks a random variant from 2 available options.
+
+Provide an image by attaching a file to your message, pasting an image URL in your message,
+or replying to a message that contains an image. You can also mention a user (`@username`)
+to use their avatar.
+
+Run `z obama [number]`. To select a specific variant, add its number
+(e.g., `z obama 2`). Valid range: 1–2.

--- a/MariBot-Core/Resources/Help/ocr.md
+++ b/MariBot-Core/Resources/Help/ocr.md
@@ -1,0 +1,11 @@
+# ocr
+
+Extract text from an image using OCR.
+
+Provide an image by attaching a file to your message, pasting an image URL in your message,
+or replying to a message that contains an image. You can also mention a user (`@username`)
+to use their avatar.
+
+Run `z ocr [text]`.
+
+Optional text is appended after the extracted content.

--- a/MariBot-Core/Resources/Help/pence.md
+++ b/MariBot-Core/Resources/Help/pence.md
@@ -1,0 +1,9 @@
+# pence
+
+Apply the Pence meme template.
+
+Provide an image by attaching a file to your message, pasting an image URL in your message,
+or replying to a message that contains an image. You can also mention a user (`@username`)
+to use their avatar.
+
+Run `z pence`.

--- a/MariBot-Core/Resources/Help/popcorn.md
+++ b/MariBot-Core/Resources/Help/popcorn.md
@@ -1,0 +1,9 @@
+# popcorn
+
+Apply the Popcorn Reaction meme template.
+
+Provide an image by attaching a file to your message, pasting an image URL in your message,
+or replying to a message that contains an image. You can also mention a user (`@username`)
+to use their avatar.
+
+Run `z popcorn`.

--- a/MariBot-Core/Resources/Help/pricecharting.md
+++ b/MariBot-Core/Resources/Help/pricecharting.md
@@ -1,0 +1,5 @@
+# pricecharting
+
+Search for a game's current price on PriceCharting.
+
+**Usage:** `z pricecharting <game name>`

--- a/MariBot-Core/Resources/Help/queen.md
+++ b/MariBot-Core/Resources/Help/queen.md
@@ -1,0 +1,5 @@
+# queen
+
+Generate a Queen character image with custom text.
+
+**Usage:** `z queen <text>`

--- a/MariBot-Core/Resources/Help/r34.md
+++ b/MariBot-Core/Resources/Help/r34.md
@@ -1,0 +1,12 @@
+# r34
+
+Fetch a random image from Rule34.
+
+## Usage
+
+`z r34 [tags]`
+
+## Notes
+
+- Tags are optional and space-separated (e.g., `z r34 landscape sky`).
+- *NSFW — only works in NSFW-designated channels.*

--- a/MariBot-Core/Resources/Help/radar.md
+++ b/MariBot-Core/Resources/Help/radar.md
@@ -1,0 +1,14 @@
+# radar
+
+Display the current weather radar for a US state or region.
+
+**Usage:** `z radar [stateCode]`
+
+Defaults to `WA` (Washington) if no state code is provided.
+
+## Supported State Codes
+
+`WA` `OR` `CA` `NV` `CO` `UT` `AZ` `NM` `ID` `MT` `WY` `ND` `SD` `NE` `KS` `OK`
+`TX` `MN` `WI` `IA` `MO` `AR` `LA` `IL` `IN` `OH` `KY` `TN` `MS` `MI` `VA` `MD`
+`DC` `WV` `NC` `SC` `GA` `AL` `FL` `PA` `NY` `NH` `VT` `ME` `MA` `CT` `RI` `NJ`
+`DE` `US` (national view)

--- a/MariBot-Core/Resources/Help/radical.md
+++ b/MariBot-Core/Resources/Help/radical.md
@@ -1,0 +1,10 @@
+# radical
+
+Apply the Radical Reggie meme template. Picks a random variant from 2 available options.
+
+Provide an image by attaching a file to your message, pasting an image URL in your message,
+or replying to a message that contains an image. You can also mention a user (`@username`)
+to use their avatar.
+
+Run `z radical [number]`. To select a specific variant, add its number
+(e.g., `z radical 2`). Valid range: 1–2.

--- a/MariBot-Core/Resources/Help/radio.md
+++ b/MariBot-Core/Resources/Help/radio.md
@@ -1,0 +1,13 @@
+# radio
+
+Interact with radio station streams.
+
+## Commands
+
+- `z radio list` — List available radio stations.
+- `z radio play <station>` — Play a radio station in your voice channel.
+- `z radio stop` — Stop the currently playing station.
+
+## Notes
+
+- You must be in a voice channel to use playback commands.

--- a/MariBot-Core/Resources/Help/reagan-tts.md
+++ b/MariBot-Core/Resources/Help/reagan-tts.md
@@ -1,0 +1,5 @@
+# reagan-tts
+
+Speak text in the voice of Ronald Reagan.
+
+**Usage:** `z reagan-tts <text>`

--- a/MariBot-Core/Resources/Help/reagan.md
+++ b/MariBot-Core/Resources/Help/reagan.md
@@ -1,0 +1,9 @@
+# reagan
+
+Apply the Ronald Reagan meme template.
+
+Provide an image by attaching a file to your message, pasting an image URL in your message,
+or replying to a message that contains an image. You can also mention a user (`@username`)
+to use their avatar.
+
+Run `z reagan`.

--- a/MariBot-Core/Resources/Help/realbooru.md
+++ b/MariBot-Core/Resources/Help/realbooru.md
@@ -1,0 +1,12 @@
+# realbooru
+
+Fetch a random image from Realbooru.
+
+## Usage
+
+`z realbooru [tags]`
+
+## Notes
+
+- Tags are optional and space-separated (e.g., `z realbooru landscape sky`).
+- *NSFW — only works in NSFW-designated channels.*

--- a/MariBot-Core/Resources/Help/rgt.md
+++ b/MariBot-Core/Resources/Help/rgt.md
@@ -1,0 +1,9 @@
+# rgt
+
+Apply an RGT logo overlay.
+
+Provide an image by attaching a file to your message, pasting an image URL in your message,
+or replying to a message that contains an image. You can also mention a user (`@username`)
+to use their avatar.
+
+Run `z rgt`.

--- a/MariBot-Core/Resources/Help/safebooru.md
+++ b/MariBot-Core/Resources/Help/safebooru.md
@@ -1,0 +1,11 @@
+# safebooru
+
+Fetch a random image from Safebooru.
+
+## Usage
+
+`z safebooru [tags]`
+
+## Notes
+
+- Tags are optional and space-separated (e.g., `z safebooru landscape sky`).

--- a/MariBot-Core/Resources/Help/sakugabooru.md
+++ b/MariBot-Core/Resources/Help/sakugabooru.md
@@ -1,0 +1,11 @@
+# sakugabooru
+
+Fetch a random image from Sakugabooru.
+
+## Usage
+
+`z sakugabooru [tags]`
+
+## Notes
+
+- Tags are optional and space-separated (e.g., `z sakugabooru landscape sky`).

--- a/MariBot-Core/Resources/Help/sankakucomplex.md
+++ b/MariBot-Core/Resources/Help/sankakucomplex.md
@@ -1,0 +1,12 @@
+# sankakucomplex
+
+Fetch a random image from Sankaku Complex.
+
+## Usage
+
+`z sankakucomplex [tags]`
+
+## Notes
+
+- Tags are optional and space-separated (e.g., `z sankakucomplex landscape sky`).
+- *NSFW — only works in NSFW-designated channels.*

--- a/MariBot-Core/Resources/Help/scarecrow.md
+++ b/MariBot-Core/Resources/Help/scarecrow.md
@@ -1,0 +1,10 @@
+# scarecrow
+
+Apply the Scarecrow meme template. Picks a random variant from 5 available options.
+
+Provide an image by attaching a file to your message, pasting an image URL in your message,
+or replying to a message that contains an image. You can also mention a user (`@username`)
+to use their avatar.
+
+Run `z scarecrow [number]`. To select a specific variant, add its number
+(e.g., `z scarecrow 3`). Valid range: 1–5.

--- a/MariBot-Core/Resources/Help/server.md
+++ b/MariBot-Core/Resources/Help/server.md
@@ -1,0 +1,9 @@
+# server
+
+Display information about the bot's host machine.
+
+## Commands
+
+- `z server ping` — Replies with the current Discord API latency in milliseconds.
+- `z server health` — Displays an embed with the host machine's current CPU usage, available
+  memory, and free/total disk space for each drive.

--- a/MariBot-Core/Resources/Help/solve.md
+++ b/MariBot-Core/Resources/Help/solve.md
@@ -1,0 +1,5 @@
+# solve
+
+Solve a mathematical equation and display the result.
+
+**Usage:** `z solve <equation>`

--- a/MariBot-Core/Resources/Help/sonicsays.md
+++ b/MariBot-Core/Resources/Help/sonicsays.md
@@ -1,0 +1,5 @@
+# sonicsays
+
+Generate a "Sonic Says" panel with custom text.
+
+**Usage:** `z sonicsays <text>`

--- a/MariBot-Core/Resources/Help/spawnwave.md
+++ b/MariBot-Core/Resources/Help/spawnwave.md
@@ -1,0 +1,9 @@
+# spawnwave
+
+Apply the Spawn Wave meme template.
+
+Provide an image by attaching a file to your message, pasting an image URL in your message,
+or replying to a message that contains an image. You can also mention a user (`@username`)
+to use their avatar.
+
+Run `z spawnwave`.

--- a/MariBot-Core/Resources/Help/spongebob.md
+++ b/MariBot-Core/Resources/Help/spongebob.md
@@ -1,0 +1,7 @@
+# spongebob
+
+Mock SpongeBob mocking meme — alternates the case of each character.
+
+**Usage:** `z spongebob [text]`
+
+If no text is provided, the most recent message in the channel is used.

--- a/MariBot-Core/Resources/Help/statictext.md
+++ b/MariBot-Core/Resources/Help/statictext.md
@@ -1,0 +1,19 @@
+# statictext
+
+Manage custom text responses for this server.
+
+## Commands
+
+- `z statictext add <key> <text>` — Add a new guild-specific response.
+- `z statictext update <key> <text>` — Update an existing guild-specific response.
+- `z statictext remove <key>` — Remove a guild-specific response.
+- `z statictext list` — List all available static text commands (global and guild).
+- `z statictext addglobal <key> <text>` *(Owner only)* — Add a global response available in all servers.
+- `z statictext updateglobal <key> <text>` *(Owner only)* — Update a global response.
+- `z statictext removeglobal <key>` *(Owner only)* — Remove a global response.
+- `z statictext promote <key>` *(Owner only)* — Promote a guild response to global.
+
+## Notes
+
+- Responses can include text and/or attachments.
+- Static text commands are invoked directly by their key (e.g., `z mykey`).

--- a/MariBot-Core/Resources/Help/stephenasmith.md
+++ b/MariBot-Core/Resources/Help/stephenasmith.md
@@ -1,0 +1,5 @@
+# stephenasmith
+
+Speak text in the voice of Stephen A. Smith.
+
+**Usage:** `z stephenasmith <text>`

--- a/MariBot-Core/Resources/Help/transactiondenied.md
+++ b/MariBot-Core/Resources/Help/transactiondenied.md
@@ -1,0 +1,7 @@
+# transactiondenied
+
+Generate a "Transaction Denied" meme.
+
+**Usage:** `z transactiondenied [text]`
+
+Text is optional.

--- a/MariBot-Core/Resources/Help/trump.md
+++ b/MariBot-Core/Resources/Help/trump.md
@@ -1,0 +1,10 @@
+# trump
+
+Apply the Trump meme template. Picks a random variant from 8 available options.
+
+Provide an image by attaching a file to your message, pasting an image URL in your message,
+or replying to a message that contains an image. You can also mention a user (`@username`)
+to use their avatar.
+
+Run `z trump [number]`. To select a specific variant, add its number
+(e.g., `z trump 4`). Valid range: 1–8.

--- a/MariBot-Core/Resources/Help/urban.md
+++ b/MariBot-Core/Resources/Help/urban.md
@@ -1,0 +1,5 @@
+# urban
+
+Look up a word or phrase on Urban Dictionary.
+
+**Usage:** `z urban <word>`

--- a/MariBot-Core/Resources/Help/urbanrand.md
+++ b/MariBot-Core/Resources/Help/urbanrand.md
@@ -1,0 +1,5 @@
+# urbanrand
+
+Get a random Urban Dictionary definition.
+
+**Usage:** `z urbanrand`

--- a/MariBot-Core/Resources/Help/uwu.md
+++ b/MariBot-Core/Resources/Help/uwu.md
@@ -1,0 +1,7 @@
+# uwu
+
+Uwuify text (replaces r/l with w, adds nyaa-style modifications, etc.).
+
+**Usage:** `z uwu [text]`
+
+If no text is provided, the most recent message in the channel is uwuified.

--- a/MariBot-Core/Resources/Help/vote.md
+++ b/MariBot-Core/Resources/Help/vote.md
@@ -1,0 +1,5 @@
+# vote
+
+Submit a vote for a poll.
+
+**Usage:** `z vote <pollKey> [choice]`

--- a/MariBot-Core/Resources/Help/voteresults.md
+++ b/MariBot-Core/Resources/Help/voteresults.md
@@ -1,0 +1,5 @@
+# voteresults
+
+Display the current results for a poll.
+
+**Usage:** `z voteresults <pollKey>`

--- a/MariBot-Core/Resources/Help/wa.md
+++ b/MariBot-Core/Resources/Help/wa.md
@@ -1,0 +1,5 @@
+# wa
+
+Query Wolfram Alpha for a quick answer.
+
+**Usage:** `z wa <query>`

--- a/MariBot-Core/Resources/Help/webcam.md
+++ b/MariBot-Core/Resources/Help/webcam.md
@@ -1,0 +1,12 @@
+# webcam
+
+Fetch images from configured webcam feeds.
+
+## Commands
+
+- `z webcam list` — List available webcam feeds.
+- `z webcam <name>` — Fetch the latest image from the named webcam.
+
+## Notes
+
+- Available webcams are configured in `webcams.json`.

--- a/MariBot-Core/Resources/Help/wiki.md
+++ b/MariBot-Core/Resources/Help/wiki.md
@@ -1,0 +1,5 @@
+# wiki
+
+Display a Wikipedia article summary.
+
+**Usage:** `z wiki <topic>`

--- a/MariBot-Core/Resources/Help/wikisearch.md
+++ b/MariBot-Core/Resources/Help/wikisearch.md
@@ -1,0 +1,5 @@
+# wikisearch
+
+List Wikipedia search results for a topic.
+
+**Usage:** `z wikisearch <topic>`

--- a/MariBot-Core/Resources/Help/xbooru.md
+++ b/MariBot-Core/Resources/Help/xbooru.md
@@ -1,0 +1,12 @@
+# xbooru
+
+Fetch a random image from Xbooru.
+
+## Usage
+
+`z xbooru [tags]`
+
+## Notes
+
+- Tags are optional and space-separated (e.g., `z xbooru landscape sky`).
+- *NSFW — only works in NSFW-designated channels.*

--- a/MariBot-Core/Resources/Help/yandere.md
+++ b/MariBot-Core/Resources/Help/yandere.md
@@ -1,0 +1,13 @@
+# yandere
+
+Fetch a random image from Yandere.
+
+## Usage
+
+`z yandere [tags]`
+
+## Notes
+
+- Tags are optional and space-separated (e.g., `z yandere landscape sky`).
+- Includes post metadata (score, tags) in the response.
+- *NSFW — only works in NSFW-designated channels.*

--- a/MariBot-Core/Resources/Help/ye.md
+++ b/MariBot-Core/Resources/Help/ye.md
@@ -1,0 +1,5 @@
+# ye
+
+Speak text in the voice of Kanye West.
+
+**Usage:** `z ye <text>`

--- a/MariBot-Core/Resources/Help/yoda.md
+++ b/MariBot-Core/Resources/Help/yoda.md
@@ -1,0 +1,5 @@
+# yoda
+
+Speak text in the voice of Yoda.
+
+**Usage:** `z yoda <text>`

--- a/MariBot-Core/Services/CommandHandlingService.cs
+++ b/MariBot-Core/Services/CommandHandlingService.cs
@@ -69,6 +69,31 @@ namespace MariBot.Core.Services
 
             await commandService.AddModulesAsync(Assembly.GetEntryAssembly(), serviceProvider);
             await interactionService.AddModulesAsync(Assembly.GetEntryAssembly(), serviceProvider);
+
+            // Boot-time check: warn if any statictext commands shadow registered bot commands
+            var topLevelTextNames = commandService.Commands
+                .SelectMany(c => c.Aliases)
+                .Select(a => a.Split(' ')[0].ToLowerInvariant())
+                .ToHashSet();
+            var slashNames = interactionService.SlashCommands
+                .Select(c => c.Name.ToLowerInvariant())
+                .ToHashSet();
+
+            var allStaticResponses = staticTextResponseService.GetAllResponses();
+            if (allStaticResponses != null)
+            {
+                foreach (var response in allStaticResponses)
+                {
+                    var lower = response.Command.ToLowerInvariant();
+                    if (topLevelTextNames.Contains(lower) || slashNames.Contains(lower))
+                    {
+                        logger.LogWarning(
+                            "Static text response \"{}\" ({}) conflicts with a registered bot command and will never be served.",
+                            response.Command,
+                            response.IsGlobal ? "global" : $"guild:{response.GuildId}");
+                    }
+                }
+            }
         }
 
         private Task ComponentCommandExecuted(ComponentCommandInfo arg1, Discord.IInteractionContext arg2, Discord.Interactions.IResult arg3)

--- a/MariBot-Core/Services/DataService.cs
+++ b/MariBot-Core/Services/DataService.cs
@@ -18,11 +18,12 @@ namespace MariBot.Core.Services
     public class DataService
     {
         private readonly ILogger<DataService> logger;
-        private static LiteDatabase db = new LiteDatabase("data.db");
+        private readonly LiteDatabase db;
 
-        public DataService(ILogger<DataService> logger)
+        public DataService(ILogger<DataService> logger, string dbPath = "data.db")
         {
             this.logger = logger;
+            db = new LiteDatabase(dbPath);
 
             logger.LogInformation("DB init in progress...");
 

--- a/MariBot-Core/Services/DataService.cs
+++ b/MariBot-Core/Services/DataService.cs
@@ -213,7 +213,6 @@ namespace MariBot.Core.Services
             return true;
         }
 
-
         /// <summary>
         /// Deletes an existing StaticTextResponse in the DB.
         /// </summary>

--- a/MariBot-Core/Services/GrokService.cs
+++ b/MariBot-Core/Services/GrokService.cs
@@ -98,6 +98,40 @@ public class GrokService
     }
 
     /// <summary>
+    /// Edits an image (or combines two images) using Grok's image editing tool
+    /// </summary>
+    /// <param name="prompt">Editing instructions</param>
+    /// <param name="imageUrls">1-2 image URLs to edit</param>
+    /// <returns>URL of the edited image</returns>
+    public virtual async Task<string> GetGrokImageEditAsync(string prompt, List<string> imageUrls)
+    {
+        var imageClient = new Image.ImageClient(grpcChannel);
+
+        var request = new GenerateImageRequest
+        {
+            Model = dynamicConfigService.GetGrokImageModel(),
+            Prompt = prompt,
+            N = 1,
+            Format = ImageFormat.ImgFormatUrl
+        };
+
+        if (imageUrls.Count == 1)
+        {
+            request.Image = new ImageUrlContent { ImageUrl = imageUrls[0] };
+        }
+        else
+        {
+            foreach (var url in imageUrls)
+            {
+                request.Images.Add(new ImageUrlContent { ImageUrl = url });
+            }
+        }
+
+        var response = await imageClient.GenerateImageAsync(request, headers);
+        return response.Images.First().Url;
+    }
+
+    /// <summary>
     /// Generates a video using Grok's video generation tool
     /// </summary>
     /// <param name="prompt">Prompt</param>

--- a/MariBot-Core/Services/OpenAIService.cs
+++ b/MariBot-Core/Services/OpenAIService.cs
@@ -229,12 +229,6 @@ namespace MariBot.Core.Services
                 var gptResult = await chatClient.CompleteChatAsync(messages, chatCompletionOptions);
                 var gptContent = gptResult.Value.Content.First().Text;
 
-                // Trim to meet Discord message length limits
-                if (gptContent.Length > 1992)
-                {
-                    gptContent = gptContent[..1992];
-                }
-
                 return gptContent;
             }
             catch (Exception ex)

--- a/MariBot-Core/Services/OpenAIService.cs
+++ b/MariBot-Core/Services/OpenAIService.cs
@@ -216,7 +216,6 @@ namespace MariBot.Core.Services
                     return "Input failed safety checks.";
                 }
 
-
                 ChatCompletionOptions chatCompletionOptions = new ChatCompletionOptions
                 {
                     EndUserId = userid

--- a/MariBot-Core/Services/StaticTextResponseService.cs
+++ b/MariBot-Core/Services/StaticTextResponseService.cs
@@ -136,7 +136,6 @@ namespace MariBot.Core.Services
                 }
             }
 
-
             var newResponse = new StaticTextResponse
             {
                 Command = command,

--- a/MariBot-Core/Services/StaticTextResponseService.cs
+++ b/MariBot-Core/Services/StaticTextResponseService.cs
@@ -1,4 +1,6 @@
 ﻿using Discord;
+using Discord.Commands;
+using Discord.Interactions;
 using MariBot.Core.Models;
 using Newtonsoft.Json;
 using RestSharp.Extensions;
@@ -6,21 +8,46 @@ using RestSharp.Extensions;
 namespace MariBot.Core.Services
 {
     /// <summary>
-    /// Service providing static text response retrieval and management. 
+    /// Service providing static text response retrieval and management.
     /// </summary>
     public class StaticTextResponseService
     {
         public static readonly string LegacyGlobalPath = Environment.CurrentDirectory + "\\data\\global\\textresponse.json";
 
         private readonly DataService dataService;
+        private readonly CommandService commandService;
+        private readonly InteractionService interactionService;
 
         private static readonly string UserAgent =
             "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4414.0 Safari/537.36 Edg/90.0.803.0";
 
-        public StaticTextResponseService(DataService dataService)
+        public StaticTextResponseService(DataService dataService, CommandService commandService, InteractionService interactionService)
         {
             this.dataService = dataService;
+            this.commandService = commandService;
+            this.interactionService = interactionService;
         }
+
+        private bool IsExistingBotCommand(string command)
+        {
+            var lower = command.ToLowerInvariant();
+            var textCommandTopLevel = commandService.Commands
+                .SelectMany(c => c.Aliases)
+                .Select(a => a.Split(' ')[0].ToLowerInvariant())
+                .ToHashSet();
+            var slashCommandNames = interactionService.SlashCommands
+                .Select(c => c.Name.ToLowerInvariant())
+                .ToHashSet();
+            return textCommandTopLevel.Contains(lower) || slashCommandNames.Contains(lower);
+        }
+
+        public List<StaticTextResponse>? GetAllResponses() => dataService.GetStaticTextResponse();
+
+        public List<StaticTextResponse> GetGlobalResponses()
+            => dataService.GetStaticTextResponse()?.Where(r => r.IsGlobal).ToList() ?? new List<StaticTextResponse>();
+
+        public List<StaticTextResponse> GetGuildResponses(ulong guildId)
+            => dataService.GetStaticTextResponse()?.Where(r => !r.IsGlobal && r.GuildId == guildId).ToList() ?? new List<StaticTextResponse>();
 
         /// <summary>
         /// Gets a static text response
@@ -48,6 +75,16 @@ namespace MariBot.Core.Services
         /// <returns>Status message</returns>
         public async Task<string> AddNewResponse(string command, string text, ulong guild, List<Attachment>? discordAttachments, bool isGlobal)
         {
+            // Blank validation
+            if (string.IsNullOrWhiteSpace(command))
+                return "Command name cannot be blank.";
+            if (string.IsNullOrWhiteSpace(text) && (discordAttachments == null || discordAttachments.Count == 0))
+                return "Response cannot be blank. Provide text or attach a file.";
+
+            // Bot command conflict check
+            if (IsExistingBotCommand(command))
+                return $"Failed to add command. \"{command}\" conflicts with an existing bot command.";
+
             var stringParts = text.Split(" ");
             var attachments = new Dictionary<string, byte[]>();
             var partsToRemove = new List<string>();
@@ -132,8 +169,16 @@ namespace MariBot.Core.Services
 
             if (noExistingGlobalResponse)
             {
+                // Explicit duplicate check (gives clear error instead of generic DB failure)
+                if (dataService.GetStaticTextResponse(newResponse.Id) != null)
+                {
+                    return isGlobal
+                        ? "Failed to add command. A global command with this name already exists."
+                        : "Failed to add command. A guild command with this name already exists.";
+                }
+
                 var isSuccess = dataService.InsertStaticTextResponse(newResponse);
-                return isSuccess ? "OK" : "Failed to add command. It may already exist or there is a problem with the database.";
+                return isSuccess ? "OK" : "Failed to add command. There is a problem with the database.";
             }
             else
             {
@@ -151,6 +196,16 @@ namespace MariBot.Core.Services
         /// <returns>Status message</returns>
         public async Task<string> UpdateResponse(string command, string text, ulong guild, List<Attachment>? discordAttachments, bool isGlobal)
         {
+            // Blank validation
+            if (string.IsNullOrWhiteSpace(command))
+                return "Command name cannot be blank.";
+            if (string.IsNullOrWhiteSpace(text) && (discordAttachments == null || discordAttachments.Count == 0))
+                return "Response cannot be blank. Provide text or attach a file.";
+
+            // Bot command conflict check
+            if (IsExistingBotCommand(command))
+                return $"Failed to update command. \"{command}\" conflicts with an existing bot command.";
+
             var stringParts = text.Split(" ");
             var attachments = new Dictionary<string, byte[]>();
             var partsToRemove = new List<string>();
@@ -274,6 +329,51 @@ namespace MariBot.Core.Services
 
             var isSuccess = dataService.DeleteStaticTextResponse(newResponse);
             return isSuccess ? "OK" : "Failed to delete command. It may not exist or there is a problem with the database.";
+        }
+
+        /// <summary>
+        /// Promotes a guild-specific static text response to global.
+        /// Checks that no other guild has the same command before promoting.
+        /// Removes the original guild-specific entry after promotion.
+        /// </summary>
+        public string PromoteToGlobal(string command, ulong guild)
+        {
+            var guildEntry = dataService.GetStaticTextResponse(GenerateId(command, guild));
+            if (guildEntry == null)
+                return $"Command \"{command}\" not found in this guild's responses.";
+
+            var globalEntry = dataService.GetStaticTextResponse(GenerateId(command));
+            if (globalEntry != null)
+                return $"Failed to promote. A global command named \"{command}\" already exists.";
+
+            // Check for other guilds with the same command name
+            var allResponses = dataService.GetStaticTextResponse();
+            var conflicts = allResponses?
+                .Where(r => !r.IsGlobal && r.GuildId != guild &&
+                            r.Command.Equals(command, StringComparison.OrdinalIgnoreCase))
+                .ToList();
+
+            if (conflicts != null && conflicts.Count > 0)
+            {
+                var guildIds = string.Join(", ", conflicts.Select(r => r.GuildId.ToString()));
+                return $"Failed to promote. Other guilds have the same command: {guildIds}";
+            }
+
+            // Create global version
+            var newGlobal = new StaticTextResponse
+            {
+                Command = command,
+                Message = guildEntry.Message,
+                IsGlobal = true,
+                Attachments = guildEntry.Attachments
+            };
+
+            if (!dataService.InsertStaticTextResponse(newGlobal))
+                return "Failed to create global entry. There may be a database problem.";
+
+            // Remove guild-specific version (true move)
+            dataService.DeleteStaticTextResponse(guildEntry);
+            return "OK";
         }
 
         /// <summary>

--- a/MariBot-Core/Utils/PaginationHelpers.cs
+++ b/MariBot-Core/Utils/PaginationHelpers.cs
@@ -1,8 +1,8 @@
 using Discord;
 
-namespace MariBot.Core.Modules.Text
+namespace MariBot.Core.Utils
 {
-    public static class StaticTextListHelpers
+    public static class PaginationHelpers
     {
         private const int MaxDescriptionLength = 3500;
 

--- a/MariBot-Core/dynamic-config.json
+++ b/MariBot-Core/dynamic-config.json
@@ -62,7 +62,9 @@
         "dallehd",
         "flux",
         "grok",
-        "grokimage"
+        "grokimage",
+        "grokvideo",
+        "grokedit"
       ]
     },
     {
@@ -146,6 +148,8 @@
         "gpt5",
         "grok",
         "grokimage",
+        "grokvideo",
+        "grokedit",
         "flux",
         "dalle",
         "gptimage"


### PR DESCRIPTION
## Summary
- **Static text commands**: New commands, improved reliability, duplicate-safe add/remove, paginated list display
- **File-based help system**: Markdown help files in `Resources/Help/` with accurate per-command documentation; `!help <command>` now reads from these files
- **Grok image editing**: New `grokedit` command supporting up to 2 images from attachments, replies, URLs, or channel history
- **Grok video generation**: New `grokvideo` command (owner-only, 1-10 seconds)
- **AI response pagination**: Long responses from `grok`, `gpt3`, `gpt4`, `gpt5` are split across multiple messages instead of being truncated
- **Dynamic config**: `grokvideo` and `grokedit` blocked on servers that don't have grok access

## Test plan
- [x] `dotnet build MariBot.sln` — 0 errors
- [x] `dotnet test MariBot.sln` — all tests pass
- [x] Verify `grokedit` with attachment, reply, URL, and history fallback sources
- [x] Verify long AI responses split into multiple messages
- [x] Verify `!help <command>` returns correct markdown content

🤖 Generated with [Claude Code](https://claude.com/claude-code)