### PR TITLE
fix: Update GPT-3.5 model to gpt-3.5-turbo-0125 ahead of deprecation

### DIFF
--- a/MariBot-Core/Services/OpenAIService.cs
+++ b/MariBot-Core/Services/OpenAIService.cs
@@ -39,7 +39,7 @@ namespace MariBot.Core.Services
                 OrganizationId = orgId
             };
 
-            gpt3Client = new ChatClient("gpt-3.5-turbo-1106", apiKeyCredential, openAIClientOptions);
+            gpt3Client = new ChatClient("gpt-3.5-turbo-0125", apiKeyCredential, openAIClientOptions);
             gpt4Client = new ChatClient("gpt-4.1", apiKeyCredential, openAIClientOptions);
             gpt5Client = new ChatClient("gpt-5", apiKeyCredential, openAIClientOptions);
 


### PR DESCRIPTION
gpt-3.5-turbo-1106 is scheduled for shutdown on September 28, 2026.